### PR TITLE
funktion paluuarvon tyyppivihjeen esittely

### DIFF
--- a/data/osa-4/2-lisaa-funktioista.md
+++ b/data/osa-4/2-lisaa-funktioista.md
@@ -597,6 +597,15 @@ def tulosta_monesti(viesti : str, kerrat : int):
 
 Tämä kertoo funktion käyttäjälle, että parametrin `viesti` on tarkoitus olla merkkijono, kun taas parametrin `kerrat` on tarkoitus olla kokonaisluku.
 
-Huomaa kuitenkin, että tyyppivihje ainoastaan neuvoo, mikä tyypin tulisi olla, mutta ei valvo sitä. Jos funktiolle annetaan väärän tyyppinen parametri, funktio suoritetaan kuitenkin, mutta se toimii mahdollisesti väärin.
+Vastaavasti funktion paaluarvon tyypin voi vihjata funktion määrittelyssä:
+
+```python
+def summa(a: int, b: int) -> int:
+    return a+b
+```
+
+Tämä kertoo funktion käyttäjälle, että funktion on tarkoitus palauttaa kokonaisluku. 
+
+Huomaa kuitenkin, että tyyppivihje ainoastaan neuvoo, mikä tyypin tulisi olla, mutta ei valvo sitä. Jos funktiolle annetaan väärän tyyppinen parametri, funktio suoritetaan kuitenkin, mutta se toimii mahdollisesti väärin. 
 
 <quiz id="d752142a-9e54-5cdb-acb9-b19c9bf4673e"></quiz>


### PR DESCRIPTION
Paluuarvon tyyppivihje ilmestyy käyttöön ilman selitystä kappaleessa 5.2, sen esittely sopisi kappaleen 4.2 loppuun. 

Tähän voisi myös lisätä maininnan, että on tarjolla työkaluja, jotka hoitavat tyyppitarkistuksen (ja paljon muuta). Joku näitä paremmin tunteva voisi ehkä jopa vinkata hyviä työkaluja?